### PR TITLE
llbqInjector.csx fatal error on steam version

### DIFF
--- a/llbqInjector.csx
+++ b/llbqInjector.csx
@@ -20,7 +20,6 @@ void InjectDLL()
 				Filename = Data.Strings.MakeString("libLassebq.dll"),
 				InitScript = Data.Strings.MakeString("lassebq_init"),
 				CleanupScript = Data.Strings.MakeString("lassebq_shutdown"),
-				Kind = UndertaleExtensionKind.DLL,
 				Functions = new UndertalePointerList<UndertaleExtensionFunction>()
 				{
 					new UndertaleExtensionFunction()


### PR DESCRIPTION
fixed bug that made it impossible to use script with undertalemod tool without it causing a fatal error (exclusive to steam version for some reason). 

error: "*insert filepath here*(23,35): error: CS0117: 'UndertaleExtensionKind' does not contain a definition for 'DLL'"

solution: just remove the line of code, as it works perfectly fine without it from what we've tested

possible alternative solution: `Kind = UndertaleExtensionKind.DLL,` -> `Kind = UndertaleExtensionKind.Dll,` as we've heard this is a solution but havent tested it. (is the language even case sensitive for that?)

